### PR TITLE
v1.3.2 strip ClassName extends BaseClassName

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-simple-nameof",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Parses a class name or a dot-separated property name from a lambda expression and provides some level of type safety using type parameters.",
   "main": "index.js",
   "scripts": {

--- a/src/nameof.ts
+++ b/src/nameof.ts
@@ -14,10 +14,13 @@ export function nameof<T extends Object>(nameFunction: ((obj: T) => any) | { new
         // Theoretically could, for some ill-advised reason, be "class => class.prop".
         && !fnStr.startsWith("class =>")
     ) {
+        // check whether ClassName extends a base class
+        const terminator = fnStr.indexOf(" extends") > -1 ? fnStr.indexOf(" extends") : fnStr.indexOf(" {");
+
         return cleanseAssertionOperators(
             fnStr.substring(
                 "class ".length,
-                fnStr.indexOf(" {")
+                terminator
             )
         );
     }


### PR DESCRIPTION
Addresses [Issue #91](https://github.com/IRCraziestTaxi/ts-simple-nameof/issues/91) by stripping ` extends [BaseClassName] {`.